### PR TITLE
Implement fd sending for split unix streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sendfd"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
     "Simonas Kazlauskas <simonas@standard.ai>",
     "Bernardo Meurer <bernardo@standard.ai>",

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,12 @@
 /// of this fix it was possible for an application to busy loop waiting for changes.
 pub mod r0_4_1 {}
 
+/// Release 0.4.1
+///
+/// * Implemented [SendWithFd](crate::SendWithFd) for [tokio::net::unix::WriteHalf]
+/// * Implemented [RecvWithFd](crate::RecvWithFd) for [tokio::net::unix::ReadHalf]
+pub mod r0_4_2 {}
+
 /// Release 0.4.0
 ///
 /// * tokio 0.2 and tokio 0.3 support has been replaced by support for tokio 1.0.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,7 +6,7 @@
 /// of this fix it was possible for an application to busy loop waiting for changes.
 pub mod r0_4_1 {}
 
-/// Release 0.4.1
+/// Release 0.4.2
 ///
 /// * Implemented [SendWithFd](crate::SendWithFd) for [tokio::net::unix::WriteHalf]
 /// * Implemented [RecvWithFd](crate::RecvWithFd) for [tokio::net::unix::ReadHalf]


### PR DESCRIPTION
This implements `SendWithFd` for `tokio::net::unix::WriteHalf`, and `RecvWithFd` for `tokio::net::unix::ReadHalf`