### PR TITLE
Use doc_cfg and --all-features for documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sendfd"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     "Simonas Kazlauskas <simonas@standard.ai>",
     "Bernardo Meurer <bernardo@standard.ai>",
@@ -12,7 +12,12 @@ keywords = ["ipc"]
 license = "Apache-2.0 OR BSD-3-Clause"
 repository = "https://github.com/standard-ai/sendfd"
 documentation = "https://docs.rs/sendfd"
+readme = "README.mkd"
 
 [dependencies]
 libc = "0.2"
 tokio = { version = "1.0.0", features = [ "net" ], optional = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "sendfd_docs"]

--- a/README.mkd
+++ b/README.mkd
@@ -4,7 +4,8 @@ sendfd is a little bare-bones crate that provides APIs to send file descriptors 
 Rust.
 
 This is done by providing an extension trait that is implemented by the UNIX domain socket types
-available in the standard library. For more information, see [the documentation].
+available in the standard library and (optionally) Tokio. For more information, see [the
+documentation].
 
 There is no intention to make this crate a cross-platform abstraction (use the `ipc-channel` crate
 for that).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(sendfd_docs, feature(doc_cfg))]
+
 extern crate libc;
 #[cfg(feature = "tokio")]
 extern crate tokio;
@@ -182,6 +184,7 @@ impl SendWithFd for net::UnixStream {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl SendWithFd for tokio::net::UnixStream {
     /// Send the bytes and the file descriptors as a stream.
     ///
@@ -193,6 +196,7 @@ impl SendWithFd for tokio::net::UnixStream {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl SendWithFd for tokio::net::unix::WriteHalf<'_> {
     /// Send the bytes and the file descriptors as a stream.
     ///
@@ -216,6 +220,7 @@ impl SendWithFd for net::UnixDatagram {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl SendWithFd for tokio::net::UnixDatagram {
     /// Send the bytes and the file descriptors as a single packet.
     ///
@@ -239,6 +244,7 @@ impl RecvWithFd for net::UnixStream {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl RecvWithFd for tokio::net::UnixStream {
     /// Receive the bytes and the file descriptors from the stream.
     ///
@@ -251,6 +257,7 @@ impl RecvWithFd for tokio::net::UnixStream {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl RecvWithFd for tokio::net::unix::ReadHalf<'_> {
     /// Receive the bytes and the file descriptors from the stream.
     ///
@@ -280,6 +287,7 @@ impl RecvWithFd for net::UnixDatagram {
 }
 
 #[cfg(feature = "tokio")]
+#[cfg_attr(sendfd_docs, doc(cfg(feature = "tokio")))]
 impl RecvWithFd for tokio::net::UnixDatagram {
     /// Receive the bytes and the file descriptors as a single packet.
     ///


### PR DESCRIPTION
Otherwise it is easy to miss that `tokio` is also supported.