### PR TITLE
Add "borrowed-fd" feature for sending BorrowedFd on a socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ repository = "https://github.com/standard-ai/sendfd"
 documentation = "https://docs.rs/sendfd"
 readme = "README.mkd"
 
+[features]
+borrowed-fd = []
+
 [dependencies]
 libc = "0.2"
 tokio = { version = "1.0.0", features = [ "net" ], optional = true }


### PR DESCRIPTION
This is a more ergonomic way to use slices of ownership-safe file descriptors instead of coercing them into raw objects.